### PR TITLE
Replace outdated links to Git for Windows' wiki

### DIFF
--- a/scripts/gitBin.mts
+++ b/scripts/gitBin.mts
@@ -3,7 +3,7 @@ import { platform } from "node:process";
 
 const COMMON_GIT_BIN = "git";
 // on Git for Windows, invoking this directly is faster than simple `git` command
-// see https://github.com/git-for-windows/git/wiki/Git-wrapper#avoiding-the-git-wrapper
+// see https://gitforwindows.org/git-wrapper#avoiding-the-git-wrapper
 const WIN_GIT_EXE = "C:/Program Files/Git/mingw64/bin/git.exe";
 
 export const GIT_BIN =


### PR DESCRIPTION
Git for Windows' wiki pages were migrated in https://github.com/git-for-windows/git-for-windows.github.io/pull/59.